### PR TITLE
fixed incorrectness and nontermination bugs in calculation of "B" in …

### DIFF
--- a/Glicko2/GlickoCalculator.cs
+++ b/Glicko2/GlickoCalculator.cs
@@ -65,30 +65,28 @@ namespace Glicko2
         private static double CalculateNewVolatility(GlickoPlayer competitor, List<GlickoOpponent> opponents, double variance)
         {
             var rankingChange = RatingImprovement(competitor, opponents, variance);
-            var rankDeviation = competitor.GlickoRatingDeviation;            
+            var rankDeviation = competitor.GlickoRatingDeviation;
             
             var A = VolatilityTransform(competitor.Volatility);
             var a = VolatilityTransform(competitor.Volatility);
 
-            var k = 1;
-            double B = 0.0;
+            double B;
 
             if (Math.Pow(rankingChange, 2) > (Math.Pow(competitor.GlickoRatingDeviation, 2) + variance))
             {
                 B = Math.Log(Math.Pow(rankingChange, 2) - Math.Pow(competitor.GlickoRatingDeviation, 2) - variance);
             }
+            else
+            {
+                var k = 1;
+                double x;
 
-            if (Math.Pow(rankingChange, 2) <= (Math.Pow(competitor.GlickoRatingDeviation, 2) + variance))
-            {                
-                var x = VolatilityTransform(competitor.Volatility) - (k * VolatilityChange); 
-
-                while(VolatilityFunction(x, rankingChange, rankDeviation, variance, competitor.Volatility) < 0)
-                {
+                do {
+                    x = a - (k * VolatilityChange);
                     k++;
-                }                
+                } while (VolatilityFunction(x, rankingChange, rankDeviation, variance, competitor.Volatility) < 0);
+                B = x;
             }
-
-            B = VolatilityTransform(competitor.Volatility) - (k * VolatilityChange);
 
             var fA = VolatilityFunction(A, rankingChange, rankDeviation, variance, competitor.Volatility);
             var fB = VolatilityFunction(B, rankingChange, rankDeviation, variance, competitor.Volatility);


### PR DESCRIPTION
This fixes incorrectness and nontermination bugs in the calculation of "B" in step 5 (`CalculateNewVolatility` method).

In the old version, the while loop on line 85 would never terminate if the program enters it (`k` isn't an input to `VolatilityFunction`).  In addition, the program will always set `B` on line 91 even if `B` had been correctly set on 78.

Probably this bug hasn't come up because the rest of step 5 tries to narrow the gap between A and B, it just took longer.

I do not know why the nontermination bug never triggered.  Perhaps there is another bug lurking?

My changes are based on Step 5, Part 2 of http://www.glicko.net/glicko/glicko2.pdf (November 30, 2013 version).
